### PR TITLE
fix: Add safeStringify utility to prevent substring error on undefine…

### DIFF
--- a/src/core/agents/pes-agent.ts
+++ b/src/core/agents/pes-agent.ts
@@ -39,6 +39,7 @@ import { RuntimeProviderConfig } from '@/types/providers';
 import { generateUUID } from '@/utils/uuid';
 import { ARTError, ErrorCode } from '@/errors';
 import { Logger } from '@/utils/logger';
+import { safeStringify } from '@/utils/string-helpers';
 
 import { AgentDiscoveryService } from '@/systems/a2a/AgentDiscoveryService';
 import { TaskDelegationService } from '@/systems/a2a/TaskDelegationService';
@@ -782,7 +783,7 @@ Instructions:
 
         const summary = `
 Completed Tasks:
-${completedItems.map(i => `- ${i.description}: ${JSON.stringify(i.result).substring(0, 200)}...`).join('\n')}
+${completedItems.map(i => `- ${i.description}: ${safeStringify(i.result, 200)}`).join('\n')}
 
 Failed Tasks:
 ${failedItems.map(i => `- ${i.description}`).join('\n')}

--- a/src/systems/ui/typed-socket.ts
+++ b/src/systems/ui/typed-socket.ts
@@ -1,6 +1,7 @@
 // src/systems/ui/typed-socket.ts
 import { v4 as uuidv4 } from 'uuid';
 import { Logger } from '@/utils/logger'; // Assuming logger exists
+import { safeStringify } from '@/utils/string-helpers';
 
 export type UnsubscribeFunction = () => void;
 
@@ -61,7 +62,7 @@ export class TypedSocket<DataType, FilterType = any> {
     const socketType = this.constructor.name; // Get class name (e.g., 'LLMStreamSocket', 'ObservationSocket')
     Logger.debug(`[${socketType}] notify() called. Data type: ${typeof data}, Sub count: ${this.subscriptions.size}, Options: ${JSON.stringify(options)}`);
 
-    Logger.debug(`Notifying ${this.subscriptions.size} subscribers. Data: ${JSON.stringify(data).substring(0, 100)}..., Options: ${JSON.stringify(options)}`); // Use static Logger
+    Logger.debug(`Notifying ${this.subscriptions.size} subscribers. Data: ${safeStringify(data, 100)}, Options: ${JSON.stringify(options)}`); // Use static Logger
     this.subscriptions.forEach((sub) => {
       try {
         // 1. Check threadId if provided in both subscription options and notification options

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * @module utils/string-helpers
+ * Provides utility functions for safe string operations.
+ */
+
+/**
+ * Safely converts a value to a JSON string with optional truncation.
+ * Handles undefined, null, circular references, and other edge cases.
+ *
+ * @param value - The value to stringify
+ * @param maxLength - Maximum length of the output string (default: 200)
+ * @returns A safe string representation of the value
+ *
+ * @example
+ * safeStringify({ name: 'test' }); // '{"name":"test"}'
+ * safeStringify(undefined); // '[undefined]'
+ * safeStringify(null); // 'null'
+ * safeStringify({ long: '...' }, 50); // '{"long":"..."}...' (truncated)
+ */
+export function safeStringify(value: unknown, maxLength: number = 200): string {
+  if (value === undefined) {
+    return '[undefined]';
+  }
+
+  try {
+    const str = JSON.stringify(value);
+
+    // JSON.stringify can return undefined for certain inputs (e.g., functions, symbols)
+    if (str === undefined) {
+      return '[non-serializable]';
+    }
+
+    if (str.length <= maxLength) {
+      return str;
+    }
+
+    return str.substring(0, maxLength) + '...';
+  } catch (error) {
+    // Handle circular references or other stringify errors
+    if (error instanceof TypeError && error.message.includes('circular')) {
+      return '[circular reference]';
+    }
+    return '[stringify error]';
+  }
+}


### PR DESCRIPTION
…d values

JSON.stringify(undefined) returns undefined (not a string), causing "Cannot read properties of undefined (reading 'substring')" errors.

This fix:
- Adds safeStringify utility that safely handles undefined, null, circular refs
- Fixes pes-agent.ts synthesis phase where i.result could be undefined
- Fixes typed-socket.ts debug logging with same pattern