### PR TITLE
Add ERROR event phase for observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.16] - 2026-01-25
+
+### 🔧 ERROR Event Phase Property
+
+This release adds the `phase` property to ERROR events, providing context about which agent execution phase (planning/execution/synthesis) an error occurred in.
+
+### 📝 Changes
+
+**Fixed**:
+- ERROR events now include the `phase` property, enabling better error observability and phase-based UI error suppression
+- Planning phase errors are now correctly suppressible in UI components
+
+**Changed**:
+- Extracted `getTokenContext` to shared utility `src/utils/stream-event-helpers.ts` to eliminate code duplication across all provider adapters
+- All provider adapters (Anthropic, OpenAI, Gemini, Groq, Ollama, DeepSeek, OpenRouter) now use the shared utility
+
+**Added**:
+- `getStreamTokenContext(callContext, isThinking)`: Extracts phase and tokenType from callContext
+- `createErrorStreamEvent(error, threadId, traceId, sessionId, callContext)`: Creates ERROR events with phase
+
+### 🔍 Example Usage
+
+```typescript
+// ERROR events now include phase information
+socket.subscribe((event) => {
+  if (event.type === 'ERROR' && event.phase === 'planning') {
+    // Suppress planning phase errors - agent may retry
+    return;
+  }
+  // Show execution/synthesis phase errors to user
+  showErrorToast(event.data);
+}, ['ERROR']);
+```
+
 ## [0.4.15] - 2026-01-21
 
 ### ✨ Dynamic Todo List Change Tracking

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ✨ ART: Agentic Runtime Framework <img src="https://img.shields.io/badge/Version-v0.4.15-blue" alt="Version 0.4.15">
+# ✨ ART: Agentic Runtime Framework <img src="https://img.shields.io/badge/Version-v0.4.16-blue" alt="Version 0.4.16">
 
 <p align="center">
   <img src="docs/art-logo.jpeg" alt="ART Framework Logo" width="200"/>

--- a/docs/concepts/observations.md
+++ b/docs/concepts/observations.md
@@ -109,7 +109,7 @@ These types capture the granular progress of an LLM generation stream.
 
 ## PLAN_UPDATE Content Structure
 
-> **New in v0.4.15**: `PLAN_UPDATE` observations now include detailed change tracking.
+> **New in v0.4.16**: `PLAN_UPDATE` observations now include detailed change tracking.
 
 The `content` field of `PLAN_UPDATE` observations contains:
 

--- a/docs/concepts/pes-agent.md
+++ b/docs/concepts/pes-agent.md
@@ -91,7 +91,7 @@ For _each_ Todo item, the agent enters a mini-ReAct loop (max 5 iterations):
 
 #### Change Tracking (v0.4.15)
 
-> **New in v0.4.15**: When the agent dynamically modifies its todo list, the `PLAN_UPDATE` observation includes detailed change tracking.
+> **New in v0.4.16**: When the agent dynamically modifies its todo list, the `PLAN_UPDATE` observation includes detailed change tracking.
 
 The framework automatically tracks changes to the todo list during execution:
 

--- a/docs/how-to/connecting-your-ui.md
+++ b/docs/how-to/connecting-your-ui.md
@@ -303,7 +303,7 @@ async function loadInProgressTasks(threadId) {
 
 ## 7. Visualizing Plan Changes
 
-> **New in v0.4.15**: You can now visualize exactly how the agent's plan evolves during execution.
+> **New in v0.4.16**: You can now visualize exactly how the agent's plan evolves during execution.
 
 When the PES agent dynamically modifies its todo list (adding, modifying, or removing tasks), `PLAN_UPDATE` observations now include a `changes` field with detailed change tracking.
 

--- a/docs/how-to/pes-todolist-dynamic-modifications.md
+++ b/docs/how-to/pes-todolist-dynamic-modifications.md
@@ -267,7 +267,7 @@ const reorderedTodoList = [
 
 ## Tracking Plan Changes
 
-> **New in v0.4.15**: The ART Framework now provides detailed change tracking for dynamic todo list modifications.
+> **New in v0.4.16**: The ART Framework now provides detailed change tracking for dynamic todo list modifications.
 
 When the agent modifies its todo list during execution, `PLAN_UPDATE` observations now include a `changes` field that tells you exactly what changed—without needing to manually compare todo lists.
 
@@ -633,6 +633,6 @@ See the integration tests for examples:
 - **Remove items**: Omit items from `updatedPlan.todoList`
 - **Protection**: COMPLETED items retain their status
 - **Persistence**: Changes are automatically saved and recorded
-- **Change Tracking** (v0.4.15): `PLAN_UPDATE` observations include detailed `changes` field with `added`, `modified`, and `removed` arrays
+- **Change Tracking** (v0.4.16): `PLAN_UPDATE` observations include detailed `changes` field with `added`, `modified`, and `removed` arrays
 
 This dynamic capability enables adaptive agent behavior where the plan evolves based on real-time discoveries during execution.

--- a/docs/markdown/variables/VERSION.md
+++ b/docs/markdown/variables/VERSION.md
@@ -6,7 +6,7 @@
 
 # Variable: VERSION
 
-> `const` **VERSION**: `"0.4.15"` = `'0.4.15'`
+> `const` **VERSION**: `"0.4.16"` = `'0.4.16'`
 
 Defined in: [src/index.ts:324](https://github.com/InferQ/ART/blob/1b9328719efc8f19d3a8a92e9b589737d6fa0375/src/index.ts#L324)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "art-framework",
-  "version": "0.4.14",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "art-framework",
-      "version": "0.4.14",
+      "version": "0.4.16",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.51.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "art-framework",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Agent Runtine (ART) Framework - A browser-first JavaScript/TypeScript framework for building LLM-powered Agentic AI applications that supports MCP and A2A protocols natively",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,4 +321,4 @@ export { generateUUID } from '@/utils/uuid';
 /**
  * The current version of the ART Framework package.
  */
-export const VERSION = '0.4.15';
+export const VERSION = '0.4.16';

--- a/src/integrations/reasoning/anthropic.ts
+++ b/src/integrations/reasoning/anthropic.ts
@@ -10,6 +10,7 @@ import {
 } from '@/types';
 import { Logger } from '@/utils/logger';
 import { ARTError, ErrorCode } from '@/errors';
+import { getStreamTokenContext } from '@/utils/stream-event-helpers';
 
 // Default model if not specified
 const ANTHROPIC_DEFAULT_MODEL_ID = 'claude-3-7-sonnet-20250219';
@@ -31,37 +32,6 @@ export interface AnthropicAdapterOptions {
   defaultTemperature?: number;
 }
 
-/**
- * Helper to determine tokenType and phase based on callContext.
- * @since 0.4.11
- */
-function getTokenContext(callContext: string | undefined, isThinking: boolean): {
-  tokenType: string;
-  phase: 'planning' | 'execution' | 'synthesis' | undefined;
-} {
-  switch (callContext) {
-    case 'PLANNING_THOUGHTS':
-      return {
-        phase: 'planning',
-        tokenType: isThinking ? 'PLANNING_LLM_THINKING' : 'PLANNING_LLM_RESPONSE'
-      };
-    case 'EXECUTION_THOUGHTS':
-      return {
-        phase: 'execution',
-        tokenType: isThinking ? 'EXECUTION_LLM_THINKING' : 'EXECUTION_LLM_RESPONSE'
-      };
-    case 'SYNTHESIS_THOUGHTS':
-      return {
-        phase: 'synthesis',
-        tokenType: isThinking ? 'SYNTHESIS_LLM_THINKING' : 'SYNTHESIS_LLM_RESPONSE'
-      };
-    default:
-      return {
-        phase: undefined,
-        tokenType: isThinking ? 'LLM_THINKING' : 'LLM_RESPONSE'
-      };
-  }
-}
 
 // Types for Anthropic API interaction using the SDK
 type AnthropicSDKMessageParam = Anthropic.Messages.MessageParam;
@@ -145,7 +115,9 @@ export class AnthropicAdapter implements ProviderAdapter {
     if (!maxTokens) {
       const err = new ARTError("Anthropic API requires 'max_tokens'.", ErrorCode.INVALID_CONFIG);
       const errorGenerator = async function* (): AsyncIterable<StreamEvent> {
-        yield { type: 'ERROR', data: err, threadId, traceId, sessionId };
+        const { phase } = getStreamTokenContext(callContext, false);
+        Logger.debug(`[${traceId}] ERROR event with phase: ${phase}`, { phase, callContext });
+        yield { type: 'ERROR', data: err, phase, threadId, traceId, sessionId };
         yield { type: 'END', data: null, threadId, traceId, sessionId };
       };
       return errorGenerator();
@@ -161,7 +133,9 @@ export class AnthropicAdapter implements ProviderAdapter {
       Logger.error(`Error translating ArtStandardPrompt to Anthropic SDK format: ${error.message}`, { error, threadId, traceId });
       const artError = error instanceof ARTError ? error : new ARTError(`Prompt translation failed: ${error.message}`, ErrorCode.PROMPT_TRANSLATION_FAILED, error);
       const errorGenerator = async function* (): AsyncIterable<StreamEvent> {
-        yield { type: 'ERROR', data: artError, threadId, traceId, sessionId };
+        const { phase } = getStreamTokenContext(callContext, false);
+        Logger.debug(`[${traceId}] ERROR event with phase: ${phase}`, { phase, callContext });
+        yield { type: 'ERROR', data: artError, phase, threadId, traceId, sessionId };
         yield { type: 'END', data: null, threadId, traceId, sessionId };
       };
       return errorGenerator();
@@ -248,7 +222,7 @@ export class AnthropicAdapter implements ProviderAdapter {
                   const thinkingText = (event.content_block as any).thinking || '';
                   if (thinkingText) {
                     if (timeToFirstTokenMs === undefined) timeToFirstTokenMs = Date.now() - startTime;
-                    const { tokenType, phase } = getTokenContext(callContext, true);
+                    const { tokenType, phase } = getStreamTokenContext(callContext, true);
                     yield {
                       type: 'TOKEN',
                       data: thinkingText,
@@ -275,7 +249,7 @@ export class AnthropicAdapter implements ProviderAdapter {
                   const textDelta = event.delta.text;
                   accumulatedText += textDelta;
                   if (timeToFirstTokenMs === undefined) timeToFirstTokenMs = Date.now() - startTime;
-                  const { tokenType, phase } = getTokenContext(callContext, false);
+                  const { tokenType, phase } = getStreamTokenContext(callContext, false);
                   yield {
                     type: 'TOKEN',
                     data: textDelta,
@@ -291,7 +265,7 @@ export class AnthropicAdapter implements ProviderAdapter {
                   const thinkingDelta = (event.delta as any).thinking || '';
                   if (thinkingDelta) {
                     if (timeToFirstTokenMs === undefined) timeToFirstTokenMs = Date.now() - startTime;
-                    const { tokenType, phase } = getTokenContext(callContext, true);
+                    const { tokenType, phase } = getStreamTokenContext(callContext, true);
                     yield {
                       type: 'TOKEN',
                       data: thinkingDelta,
@@ -370,7 +344,7 @@ export class AnthropicAdapter implements ProviderAdapter {
                 }
 
                 if (finalStopReason === 'tool_use' && accumulatedToolUses.length > 0) {
-                  const { tokenType, phase } = getTokenContext(callContext, false);
+                  const { tokenType, phase } = getStreamTokenContext(callContext, false);
                   const toolData = accumulatedToolUses.map(tu => ({
                     type: 'tool_use',
                     id: tu.id,
@@ -383,7 +357,7 @@ export class AnthropicAdapter implements ProviderAdapter {
                     yield { type: 'TOKEN', data: toolData, tokenType: tokenType as any, phase, timestamp: Date.now(), ...(stepContext && { stepId: stepContext.stepId, stepDescription: stepContext.stepDescription }), threadId, traceId, sessionId };
                   }
                 } else if (accumulatedText.trim()) {
-                  const { tokenType, phase } = getTokenContext(callContext, false);
+                  const { tokenType, phase } = getStreamTokenContext(callContext, false);
                   yield { type: 'TOKEN', data: accumulatedText.trim(), tokenType: tokenType as any, phase, timestamp: Date.now(), ...(stepContext && { stepId: stepContext.stepId, stepDescription: stepContext.stepDescription }), threadId, traceId, sessionId };
                 }
 
@@ -432,7 +406,7 @@ export class AnthropicAdapter implements ProviderAdapter {
           });
           responseText = responseText.trim();
 
-          const { tokenType, phase } = getTokenContext(callContext, false);
+          const { tokenType, phase } = getStreamTokenContext(callContext, false);
 
           if (response.stop_reason === 'tool_use' && toolUseBlocks.length > 0) {
             const toolData = toolUseBlocks.map(tu => ({
@@ -473,7 +447,9 @@ export class AnthropicAdapter implements ProviderAdapter {
         const artError = error instanceof ARTError ? error :
           (error instanceof Anthropic.APIError ? new ARTError(`Anthropic API Error (${error.status}): ${error.message}`, ErrorCode.LLM_PROVIDER_ERROR, error) :
             new ARTError(error.message || 'Unknown Anthropic adapter error', ErrorCode.LLM_PROVIDER_ERROR, error));
-        yield { type: 'ERROR', data: artError, threadId, traceId, sessionId };
+        const { phase } = getStreamTokenContext(callContext, false);
+        Logger.debug(`[${traceId}] ERROR event with phase: ${phase}`, { phase, callContext });
+        yield { type: 'ERROR', data: artError, phase, threadId, traceId, sessionId };
         yield { type: 'END', data: null, threadId, traceId, sessionId };
       }
     }.bind(this);

--- a/src/integrations/reasoning/groq.ts
+++ b/src/integrations/reasoning/groq.ts
@@ -18,43 +18,13 @@ import {
 } from '@/types';
 import { Logger } from '@/utils/logger';
 import { ARTError, ErrorCode } from '@/errors';
+import { getStreamTokenContext } from '@/utils/stream-event-helpers';
 
 // Default model configuration
 const GROQ_DEFAULT_MODEL_ID = 'llama-3.3-70b-versatile';
 const GROQ_DEFAULT_MAX_TOKENS = 4096;
 const GROQ_DEFAULT_TEMPERATURE = 0.7;
 
-/**
- * Helper to determine tokenType and phase based on callContext.
- * @since 0.4.11
- */
-function getTokenContext(callContext: string | undefined, isThinking: boolean): {
-    tokenType: string;
-    phase: 'planning' | 'execution' | 'synthesis' | undefined;
-} {
-    switch (callContext) {
-        case 'PLANNING_THOUGHTS':
-            return {
-                phase: 'planning',
-                tokenType: isThinking ? 'PLANNING_LLM_THINKING' : 'PLANNING_LLM_RESPONSE'
-            };
-        case 'EXECUTION_THOUGHTS':
-            return {
-                phase: 'execution',
-                tokenType: isThinking ? 'EXECUTION_LLM_THINKING' : 'EXECUTION_LLM_RESPONSE'
-            };
-        case 'SYNTHESIS_THOUGHTS':
-            return {
-                phase: 'synthesis',
-                tokenType: isThinking ? 'SYNTHESIS_LLM_THINKING' : 'SYNTHESIS_LLM_RESPONSE'
-            };
-        default:
-            return {
-                phase: undefined,
-                tokenType: isThinking ? 'LLM_THINKING' : 'LLM_RESPONSE'
-            };
-    }
-}
 
 /**
  * Configuration options required for the `GroqAdapter`.
@@ -150,7 +120,9 @@ export class GroqAdapter implements ProviderAdapter {
             Logger.error(`Error translating ArtStandardPrompt to Groq format: ${error.message}`, { error, threadId, traceId });
             const artError = error instanceof ARTError ? error : new ARTError(`Prompt translation failed: ${error.message}`, ErrorCode.PROMPT_TRANSLATION_FAILED, error);
             const errorGenerator = async function* (): AsyncIterable<StreamEvent> {
-                yield { type: 'ERROR', data: artError, threadId, traceId, sessionId };
+                const { phase } = getStreamTokenContext(callContext, false);
+                Logger.debug(`[${traceId}] ERROR event with phase: ${phase}`, { phase, callContext });
+                yield { type: 'ERROR', data: artError, phase, threadId, traceId, sessionId };
                 yield { type: 'END', data: null, threadId, traceId, sessionId };
             };
             return errorGenerator();
@@ -208,7 +180,7 @@ export class GroqAdapter implements ProviderAdapter {
                         // Handle text content
                         if (delta?.content) {
                             accumulatedText += delta.content;
-                            const { tokenType, phase } = getTokenContext(callContext, false);
+                            const { tokenType, phase } = getStreamTokenContext(callContext, false);
                             yield { type: 'TOKEN', data: delta.content, tokenType: tokenType as any, phase, timestamp: Date.now(), ...(stepContext && { stepId: stepContext.stepId, stepDescription: stepContext.stepDescription }), threadId, traceId, sessionId };
                         }
 
@@ -240,7 +212,7 @@ export class GroqAdapter implements ProviderAdapter {
 
                     // Handle accumulated tool calls at the end of stream
                     if (accumulatedToolCalls.size > 0) {
-                        const { tokenType, phase } = getTokenContext(callContext, false);
+                        const { tokenType, phase } = getStreamTokenContext(callContext, false);
                         const toolData = Array.from(accumulatedToolCalls.values()).map(tc => ({
                             type: 'tool_use',
                             id: tc.id,
@@ -297,7 +269,7 @@ export class GroqAdapter implements ProviderAdapter {
                     const responseText = responseMessage?.content || '';
                     const toolCalls = responseMessage?.tool_calls;
 
-                    const { tokenType, phase } = getTokenContext(callContext, false);
+                    const { tokenType, phase } = getStreamTokenContext(callContext, false);
 
                     if (toolCalls && toolCalls.length > 0) {
                         const toolData = toolCalls.map((tc: ChatCompletionMessageToolCall) => ({
@@ -340,7 +312,9 @@ export class GroqAdapter implements ProviderAdapter {
                     (error instanceof Groq.APIError ?
                         new ARTError(`Groq API Error (${error.status}): ${error.message}`, ErrorCode.LLM_PROVIDER_ERROR, error) :
                         new ARTError(error.message || 'Unknown Groq adapter error', ErrorCode.LLM_PROVIDER_ERROR, error));
-                yield { type: 'ERROR', data: artError, threadId, traceId, sessionId };
+                const { phase } = getStreamTokenContext(callContext, false);
+                Logger.debug(`[${traceId}] ERROR event with phase: ${phase}`, { phase, callContext });
+                yield { type: 'ERROR', data: artError, phase, threadId, traceId, sessionId };
                 yield { type: 'END', data: null, threadId, traceId, sessionId };
             }
         }.bind(this);

--- a/src/integrations/reasoning/openai.ts
+++ b/src/integrations/reasoning/openai.ts
@@ -10,7 +10,7 @@ import {
 } from '@/types';
 import { Logger } from '@/utils/logger';
 import { ARTError, ErrorCode } from '@/errors';
-import { getStreamTokenContext } from '@/utils/stream-event-helpers';
+import { getStreamTokenContext, createErrorStreamEvent } from '@/utils/stream-event-helpers';
 
 // Default model configuration
 const OPENAI_DEFAULT_MODEL_ID = 'gpt-4o';
@@ -180,9 +180,7 @@ export class OpenAIAdapter implements ProviderAdapter {
       Logger.error(`Error translating ArtStandardPrompt to OpenAI Responses format: ${error.message}`, { error, threadId, traceId });
       const artError = error instanceof ARTError ? error : new ARTError(`Prompt translation failed: ${error.message}`, ErrorCode.PROMPT_TRANSLATION_FAILED, error);
       const errorGenerator = async function* (): AsyncIterable<StreamEvent> {
-        const { phase } = getStreamTokenContext(callContext, false);
-        Logger.debug(`[${traceId}] ERROR event with phase: ${phase}`, { phase, callContext });
-        yield { type: 'ERROR', data: artError, phase, threadId, traceId, sessionId };
+        yield createErrorStreamEvent(artError, threadId, traceId, sessionId, callContext);
         yield { type: 'END', data: null, threadId, traceId, sessionId };
       };
       return errorGenerator();
@@ -396,9 +394,7 @@ export class OpenAIAdapter implements ProviderAdapter {
           (error instanceof Error && error.message.includes('OpenAI') ?
             new ARTError(`OpenAI API Error: ${error.message}`, ErrorCode.LLM_PROVIDER_ERROR, error) :
             new ARTError(error.message || 'Unknown OpenAI adapter error', ErrorCode.LLM_PROVIDER_ERROR, error));
-        const { phase } = getStreamTokenContext(callContext, false);
-        Logger.debug(`[${traceId}] ERROR event with phase: ${phase}`, { phase, callContext });
-        yield { type: 'ERROR', data: artError, phase, threadId, traceId, sessionId };
+        yield createErrorStreamEvent(artError, threadId, traceId, sessionId, callContext);
         yield { type: 'END', data: null, threadId, traceId, sessionId };
       }
     }.bind(this);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -264,6 +264,9 @@ export interface Observation {
  * Allows for real-time delivery of tokens, metadata, errors, and lifecycle signals.
  * Adapters are responsible for translating provider-specific stream chunks into these standard events.
  *
+ * The `phase` property is populated on all event types including ERROR events, providing context
+ * about which agent execution phase the event occurred in (planning, execution, or synthesis).
+ *
  * @interface StreamEvent
  */
 export interface StreamEvent {

--- a/src/utils/stream-event-helpers.ts
+++ b/src/utils/stream-event-helpers.ts
@@ -1,0 +1,138 @@
+/**
+ * @module utils/stream-event-helpers
+ *
+ * Shared utility functions for stream event creation and context extraction.
+ * Provides consistent phase and tokenType mapping across all provider adapters.
+ *
+ * @since 0.4.16
+ */
+
+import type { StreamEvent } from '@/types';
+import { Logger } from '@/utils/logger';
+
+/**
+ * Call context values that map to agent execution phases.
+ *
+ * @typedef {'PLANNING_THOUGHTS' | 'EXECUTION_THOUGHTS' | 'SYNTHESIS_THOUGHTS' | string} CallContext
+ */
+type CallContext = 'PLANNING_THOUGHTS' | 'EXECUTION_THOUGHTS' | 'SYNTHESIS_THOUGHTS' | string;
+
+/**
+ * Token context result containing both phase and tokenType.
+ *
+ * @interface TokenContext
+ */
+export interface TokenContext {
+  /** The agent execution phase (planning, execution, synthesis, or undefined) */
+  phase: 'planning' | 'execution' | 'synthesis' | undefined;
+  /** The token type for TOKEN events */
+  tokenType: string;
+}
+
+/**
+ * Extracts phase and tokenType from callContext and thinking state.
+ *
+ * This function maps agent execution call contexts to their corresponding phases
+ * and token types for stream events. It provides the foundational logic for
+ * determining which phase an agent is in during LLM streaming.
+ *
+ * @param {CallContext | undefined} callContext - The call context identifier (e.g., 'PLANNING_THOUGHTS')
+ * @param {boolean} isThinking - Whether the token is part of a thinking/reasoning block
+ * @returns {TokenContext} Object containing phase and tokenType
+ *
+ * @example
+ * ```typescript
+ * const context = getStreamTokenContext('PLANNING_THOUGHTS', true);
+ * // Returns: { phase: 'planning', tokenType: 'PLANNING_LLM_THINKING' }
+ *
+ * const context2 = getStreamTokenContext('EXECUTION_THOUGHTS', false);
+ * // Returns: { phase: 'execution', tokenType: 'EXECUTION_LLM_RESPONSE' }
+ *
+ * const context3 = getStreamTokenContext(undefined, false);
+ * // Returns: { phase: undefined, tokenType: 'LLM_RESPONSE' }
+ * ```
+ */
+export function getStreamTokenContext(
+  callContext: CallContext | undefined,
+  isThinking: boolean
+): TokenContext {
+  switch (callContext) {
+    case 'PLANNING_THOUGHTS':
+      return {
+        phase: 'planning',
+        tokenType: isThinking ? 'PLANNING_LLM_THINKING' : 'PLANNING_LLM_RESPONSE'
+      };
+    case 'EXECUTION_THOUGHTS':
+      return {
+        phase: 'execution',
+        tokenType: isThinking ? 'EXECUTION_LLM_THINKING' : 'EXECUTION_LLM_RESPONSE'
+      };
+    case 'SYNTHESIS_THOUGHTS':
+      return {
+        phase: 'synthesis',
+        tokenType: isThinking ? 'SYNTHESIS_LLM_THINKING' : 'SYNTHESIS_LLM_RESPONSE'
+      };
+    default:
+      // Graceful fallback for unrecognized or undefined callContext
+      return {
+        phase: undefined,
+        tokenType: isThinking ? 'LLM_THINKING' : 'LLM_RESPONSE'
+      };
+  }
+}
+
+/**
+ * Creates an ERROR stream event with phase context.
+ *
+ * This helper function standardizes ERROR event creation across all provider adapters,
+ * ensuring that phase information is consistently included for observability and debugging.
+ *
+ * @param {Error | unknown} error - The error object or unknown error value
+ * @param {string} threadId - The thread identifier for the event
+ * @param {string} traceId - The trace identifier for correlation
+ * @param {string} [sessionId] - Optional session identifier for UI targeting
+ * @param {CallContext} [callContext] - Optional call context for phase extraction
+ * @returns {StreamEvent} A properly formed ERROR stream event with phase
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   // ... some operation
+ * } catch (error) {
+ *   const errorEvent = createErrorStreamEvent(
+ *     error,
+ *     threadId,
+ *     traceId,
+ *     sessionId,
+ *     'PLANNING_THOUGHTS'
+ *   );
+ *   yield errorEvent;
+ * }
+ * ```
+ */
+export function createErrorStreamEvent(
+  error: Error | unknown,
+  threadId: string,
+  traceId: string,
+  sessionId?: string,
+  callContext?: CallContext
+): StreamEvent {
+  const { phase } = getStreamTokenContext(callContext, false);
+
+  // Log for observability - helps debugging which phase errors occurred in
+  Logger.debug(`[${traceId}] Creating ERROR event with phase: ${phase || 'undefined'}`, {
+    phase,
+    callContext,
+    threadId,
+    error
+  });
+
+  return {
+    type: 'ERROR',
+    data: error,
+    phase,
+    threadId,
+    traceId,
+    sessionId
+  };
+}

--- a/test/stream-event-phase.test.ts
+++ b/test/stream-event-phase.test.ts
@@ -1,0 +1,227 @@
+/**
+ * @fileoverview Tests for stream event phase property on ERROR events
+ *
+ * Verifies that ERROR events include the `phase` property properly populated
+ * from callContext, providing observability into which agent execution phase
+ * errors occurred in.
+ *
+ * @since 0.4.16
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getStreamTokenContext, createErrorStreamEvent } from '@/utils/stream-event-helpers';
+
+describe('Stream Event Phase - ERROR Events', () => {
+  describe('getStreamTokenContext', () => {
+    it('should map PLANNING_THOUGHTS to planning phase', () => {
+      const result = getStreamTokenContext('PLANNING_THOUGHTS', false);
+      expect(result.phase).toBe('planning');
+      expect(result.tokenType).toBe('PLANNING_LLM_RESPONSE');
+    });
+
+    it('should map EXECUTION_THOUGHTS to execution phase', () => {
+      const result = getStreamTokenContext('EXECUTION_THOUGHTS', false);
+      expect(result.phase).toBe('execution');
+      expect(result.tokenType).toBe('EXECUTION_LLM_RESPONSE');
+    });
+
+    it('should map SYNTHESIS_THOUGHTS to synthesis phase', () => {
+      const result = getStreamTokenContext('SYNTHESIS_THOUGHTS', false);
+      expect(result.phase).toBe('synthesis');
+      expect(result.tokenType).toBe('SYNTHESIS_LLM_RESPONSE');
+    });
+
+    it('should return undefined phase for undefined callContext', () => {
+      const result = getStreamTokenContext(undefined, false);
+      expect(result.phase).toBeUndefined();
+      expect(result.tokenType).toBe('LLM_RESPONSE');
+    });
+
+    it('should return undefined phase for unrecognized callContext (graceful fallback)', () => {
+      const result = getStreamTokenContext('UNKNOWN_CONTEXT' as any, false);
+      expect(result.phase).toBeUndefined();
+      expect(result.tokenType).toBe('LLM_RESPONSE');
+    });
+
+    it('should distinguish thinking vs response token types', () => {
+      const planningThinking = getStreamTokenContext('PLANNING_THOUGHTS', true);
+      expect(planningThinking.tokenType).toBe('PLANNING_LLM_THINKING');
+      expect(planningThinking.phase).toBe('planning');
+
+      const planningResponse = getStreamTokenContext('PLANNING_THOUGHTS', false);
+      expect(planningResponse.tokenType).toBe('PLANNING_LLM_RESPONSE');
+      expect(planningResponse.phase).toBe('planning');
+    });
+  });
+
+  describe('createErrorStreamEvent', () => {
+    const threadId = 'test-thread-123';
+    const traceId = 'test-trace-456';
+    const sessionId = 'test-session-789';
+    const testError = new Error('Test error message');
+
+    it('should create ERROR event with planning phase', () => {
+      const event = createErrorStreamEvent(
+        testError,
+        threadId,
+        traceId,
+        sessionId,
+        'PLANNING_THOUGHTS'
+      );
+
+      expect(event.type).toBe('ERROR');
+      expect(event.phase).toBe('planning');
+      expect(event.data).toBe(testError);
+      expect(event.threadId).toBe(threadId);
+      expect(event.traceId).toBe(traceId);
+      expect(event.sessionId).toBe(sessionId);
+    });
+
+    it('should create ERROR event with execution phase', () => {
+      const event = createErrorStreamEvent(
+        testError,
+        threadId,
+        traceId,
+        sessionId,
+        'EXECUTION_THOUGHTS'
+      );
+
+      expect(event.type).toBe('ERROR');
+      expect(event.phase).toBe('execution');
+      expect(event.data).toBe(testError);
+    });
+
+    it('should create ERROR event with synthesis phase', () => {
+      const event = createErrorStreamEvent(
+        testError,
+        threadId,
+        traceId,
+        sessionId,
+        'SYNTHESIS_THOUGHTS'
+      );
+
+      expect(event.type).toBe('ERROR');
+      expect(event.phase).toBe('synthesis');
+      expect(event.data).toBe(testError);
+    });
+
+    it('should create ERROR event with undefined phase when callContext is undefined', () => {
+      const event = createErrorStreamEvent(
+        testError,
+        threadId,
+        traceId,
+        sessionId,
+        undefined
+      );
+
+      expect(event.type).toBe('ERROR');
+      expect(event.phase).toBeUndefined();
+      expect(event.data).toBe(testError);
+    });
+
+    it('should create ERROR event with undefined phase for invalid callContext (graceful fallback)', () => {
+      const event = createErrorStreamEvent(
+        testError,
+        threadId,
+        traceId,
+        sessionId,
+        'INVALID_CONTEXT' as any
+      );
+
+      expect(event.type).toBe('ERROR');
+      expect(event.phase).toBeUndefined();
+      expect(event.data).toBe(testError);
+    });
+
+    it('should handle Error objects correctly', () => {
+      const error = new Error('Specific error');
+      const event = createErrorStreamEvent(
+        error,
+        threadId,
+        traceId,
+        sessionId,
+        'PLANNING_THOUGHTS'
+      );
+
+      expect(event.data).toBe(error);
+      expect(event.phase).toBe('planning');
+    });
+
+    it('should handle unknown error types', () => {
+      const unknownError = { customError: 'something went wrong' };
+      const event = createErrorStreamEvent(
+        unknownError,
+        threadId,
+        traceId,
+        sessionId,
+        'EXECUTION_THOUGHTS'
+      );
+
+      expect(event.data).toBe(unknownError);
+      expect(event.phase).toBe('execution');
+    });
+
+    it('should create ERROR event without sessionId', () => {
+      const event = createErrorStreamEvent(
+        testError,
+        threadId,
+        traceId,
+        undefined,
+        'SYNTHESIS_THOUGHTS'
+      );
+
+      expect(event.type).toBe('ERROR');
+      expect(event.phase).toBe('synthesis');
+      expect(event.sessionId).toBeUndefined();
+    });
+
+    it('should include all required StreamEvent properties', () => {
+      const event = createErrorStreamEvent(
+        testError,
+        threadId,
+        traceId,
+        sessionId,
+        'PLANNING_THOUGHTS'
+      );
+
+      // Required properties
+      expect(event).toHaveProperty('type');
+      expect(event).toHaveProperty('data');
+      expect(event).toHaveProperty('threadId');
+      expect(event).toHaveProperty('traceId');
+
+      // Optional properties
+      expect(event).toHaveProperty('phase');
+      expect(event).toHaveProperty('sessionId');
+
+      // Verify types
+      expect(typeof event.type).toBe('string');
+      expect(typeof event.threadId).toBe('string');
+      expect(typeof event.traceId).toBe('string');
+    });
+  });
+
+  describe('Phase Mapping Consistency', () => {
+    it('should consistently map the same callContext to the same phase', () => {
+      const context1 = getStreamTokenContext('PLANNING_THOUGHTS', false);
+      const context2 = getStreamTokenContext('PLANNING_THOUGHTS', false);
+
+      expect(context1.phase).toBe(context2.phase);
+      expect(context1.tokenType).toBe(context2.tokenType);
+    });
+
+    it('should map all valid callContext values to valid phases', () => {
+      const validContexts = [
+        'PLANNING_THOUGHTS',
+        'EXECUTION_THOUGHTS',
+        'SYNTHESIS_THOUGHTS',
+      ] as const;
+
+      validContexts.forEach((context) => {
+        const result = getStreamTokenContext(context, false);
+        expect(result.phase).toBeDefined();
+        expect(result.phase).toMatch(/^(planning|execution|synthesis)$/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Extract duplicate getTokenContext to shared utility and add phase property to ERROR events across all provider adapters for better error tracking and UI suppression capabilities.